### PR TITLE
Remove old extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,6 @@
 	 "repositories": [
         {
             "type" : "vcs",
-            "url" : "https://github.com/oat-sa/extension-tao-cssdevkit.git"
-        },
-        {
-            "type" : "vcs",
             "url" : "https://github.com/oat-sa/ZendSearch"
          },
          
@@ -83,18 +79,15 @@
 		"oat-sa/extension-tao-devtools" : "dev-develop",
 		"oat-sa/extension-tao-ontobrowser" : "dev-develop",
 		"oat-sa/extension-tao-revision" : "dev-develop",
-        "oat-sa/extension-tao-mediamanager" : "dev-develop",
-		"oat-sa/extension-tao-cssdevkit" : "dev-develop",
+        	"oat-sa/extension-tao-mediamanager" : "dev-develop",
 		"oat-sa/extension-tao-clientdiag" : "dev-develop",
-        "oat-sa/extension-pcisample" : "dev-develop",
-		"oat-sa/extension-tao-theming-platform": "dev-develop",
+		"oat-sa/extension-pcisample" : "dev-develop",
 		"oat-sa/extension-tao-backoffice": "dev-develop",
 		"oat-sa/extension-tao-frontoffice": "dev-develop",
 		"oat-sa/extension-tao-testcenter": "dev-develop",
 		"oat-sa/extension-tao-proctoring": "dev-develop",
 		"oat-sa/extension-tao-workspace": "dev-develop",
 		"oat-sa/extension-tao-delivery-schedule": "dev-develop"
-
 	},
     "require-dev": {
         "phpunit/phpunit": "~4.4@dev",


### PR DESCRIPTION
Removed `oat-sa/tao-css-devkit' and `oat-sa/extension-tao-theming-platform` because they aren't up to date and prevent from bundling.