### PR TITLE
Alow rest.json to be dereferencable.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,6 +6,7 @@ SetEnv HTTP_MOD_REWRITE on
 
 #don't match resources and tests
 RewriteCond %{REQUEST_URI} 	!/views/  	[NC]
+RewriteCond %{REQUEST_URI} 	!/doc/rest.json  	[NC]
 RewriteCond %{REQUEST_URI} 	!/tao/install/	[NC]
 RewriteCond %{REQUEST_URI}  !/tao/getFile.php	[NC]
 


### PR DESCRIPTION
As /doc/rest.json is used for Web Services handshaking, I think it might be useful to allow access to it in the .htaccess file!