### PR TITLE
Separated phpunit config for unit and integration tests.

### DIFF
--- a/phpunit-integration.xml
+++ b/phpunit-integration.xml
@@ -1,0 +1,79 @@
+<phpunit bootstrap="tests/bootstrap/bootstrap.php">
+    <testsuites>
+        <testsuite name="generis">
+            <directory>generis/test/integration</directory>
+        </testsuite>
+        <testsuite name="ltiDeliveryProvider">
+            <directory>ltiDeliveryProvider/test/integration</directory>
+        </testsuite>
+        <testsuite name="qtiItemPci">
+            <directory>qtiItemPci/test/integration</directory>
+        </testsuite>
+        <testsuite name="qtiItemPic">
+            <directory>qtiItemPic/test/integration</directory>
+        </testsuite>
+        <testsuite name="tao">
+            <directory>tao/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoClientDiagnostic">
+            <directory>taoClientDiagnostic/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoDelivery">
+            <directory>taoDelivery/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoDeliveryRdf">
+            <directory>taoDeliveryRdf/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoDeliverySchedule">
+            <directory>taoDeliverySchedule/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoGroups">
+            <directory>taoGroups/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoItems">
+            <directory>taoItems/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoLti">
+            <directory>taoLti/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoMediaManager">
+            <directory>taoMediaManager/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoOpenWebItem">
+            <directory>taoOpenWebItem/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoOutcomeRds">
+            <directory>taoOutcomeRds/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoOutcomeUi">
+            <directory>taoOutcomeUi/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoProctoring">
+            <directory>taoProctoring/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoQtiItem">
+            <directory>taoQtiItem/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoQtiTest">
+            <directory>taoQtiTest/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoResultServer">
+            <directory>taoResultServer/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoRevision">
+            <directory>taoRevision/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoTestCenter">
+            <directory>taoTestCenter/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoTestLinear">
+            <directory>taoTestLinear/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoTests">
+            <directory>taoTests/test/integration</directory>
+        </testsuite>
+        <testsuite name="taoTestTaker">
+            <directory>taoTestTaker/test/integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap/bootstrap.php">
+<phpunit bootstrap="tests/bootstrap/bootstrap-unit.php">
     <testsuites>
         <testsuite name="generis">
             <directory>generis/test/unit</directory>

--- a/tests/bootstrap/bootstrap-unit.php
+++ b/tests/bootstrap/bootstrap-unit.php
@@ -23,7 +23,7 @@
  *
  */
 
-require_once __DIR__ . '/bootstrap-unit.php';
+$root_dir = __DIR__ . '/../../';
 
-//load config
-common_Config::load();
+// autoloader
+require_once $root_dir.'vendor/autoload.php';


### PR DESCRIPTION
Allows to run independently:
- unit tests: ./vendor/bin/phpunit -c phpunit.xml (not including generis.conf.php)
- integration tests: ./vendor/bin/phpunit -c phpunit-integration.xml (including generis.conf.php)