### PR TITLE
Required php ^7.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 	"homepage" : "http://www.taotesting.com",
 	"license" : "GPL-2.0",
 	"require" : {
+		"php" : "^7.1",
 		"oat-sa/generis" : "dev-develop",
 		"oat-sa/tao-core" : "dev-develop",
 		"oat-sa/extension-tao-community" : "dev-develop",


### PR DESCRIPTION
Required php ^7.1 explicitly on package-tao.
To test:
```
git clone git@github.com:oat-sa/package-tao.git
cd package-tao
git checkout develop
composer install
```
Make a standard installation.
Check that it seamlessly works.

Only impediment should be on old spielplatz.
