### PR TITLE
Revert "Required tao-core tag 27.1.3."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "homepage": "http://www.taotesting.com",
   "require": {
     "oat-sa/generis": "8.2.2",
-    "oat-sa/tao-core": "27.1.3",
+    "oat-sa/tao-core": "27.1.2",
     "oat-sa/extension-tao-community": "5.4.1",
     "oat-sa/extension-tao-funcacl": "5.3.1",
     "oat-sa/extension-tao-dac-simple": "3.2.3",


### PR DESCRIPTION
Reverts oat-sa/package-tao#55

Actually only the tao-core version in the composer.json was updated to 27.1.3 and not the composer.lock (still at 27.1.2).
