### PR TITLE
Add taoEventLog because taoProctoring require it for work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
 		"oat-sa/extension-tao-frontoffice": "dev-develop",
 		"oat-sa/extension-tao-testcenter": "dev-develop",
 		"oat-sa/extension-tao-proctoring": "dev-develop",
+		"oat-sa/extension-tao-eventlog": "dev-develop",
 		"oat-sa/extension-tao-workspace": "dev-develop",
 		"oat-sa/extension-tao-delivery-schedule": "dev-develop",
 		"oat-sa/extension-tao-testqti-previewer": "dev-develop"


### PR DESCRIPTION
We faced twice already with an issue when during updating the process failed with a generic error message that taoProctoring can not be updated. It is because taoProctoring requires taoEventLog in the manifest, but when it is missed in composer it failed because can not find proper extensions during resolving dependencies. So, as taoProctoring requires taoEventLog, it should be in composer.json too.