### PR TITLE
Require composer installers that now supports tao-extension type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
 	"homepage" : "http://www.taotesting.com",
 	"license" : "GPL-2.0",
 	"require" : {
+		"composer/installers": "~1.0",
 		"oat-sa/generis" : "dev-develop",
 		"oat-sa/tao-core" : "dev-develop",
 		"oat-sa/extension-tao-community" : "dev-develop",
@@ -69,7 +70,7 @@
 		"oat-sa/extension-tao-devtools" : "dev-develop",
 		"oat-sa/extension-tao-ontobrowser" : "dev-develop",
 		"oat-sa/extension-tao-revision" : "dev-develop",
-                "oat-sa/extension-tao-mediamanager" : "dev-develop",
+		"oat-sa/extension-tao-mediamanager" : "dev-develop",
 		"oat-sa/extension-tao-clientdiag" : "dev-develop",
 		"oat-sa/extension-pcisample" : "dev-develop",
 		"oat-sa/extension-tao-backoffice": "dev-develop",


### PR DESCRIPTION
The latest release of `composer/installers` now supports type `tao-extension` https://github.com/composer/installers/releases/tag/v1.7.0

It is mean that we can just require `composer/installers` and just write `"type": "tao-extension"` in the composer file of the extension and it will work.