### PR TITLE
Fixed composer version to use for installation and links to online installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ TAO is the first commercial-grade Open Source assessment development software on
 
 For a detailed documentation of the installation process please visit our Administrator Guide:
 
-- [Prerequisites](https://adminguide.taotesting.com/installation-and-upgrade/prerequisites)
-- [Centos, Redhat and Fedora](https://adminguide.taotesting.com/installation-and-upgrade/centos-redhat-and-fedora)
-- [MacOS Mojave](https://adminguide.taotesting.com/installation-and-upgrade/macos)
-- [Ubuntu and Debian](https://adminguide.taotesting.com/installation-and-upgrade/ubuntu-and-debian)
-- [Windows](https://adminguide.taotesting.com/installation-and-upgrade/windows)
-- [Web Installer](https://adminguide.taotesting.com/installation-and-upgrade/web-installer)
+- [Prerequisites](https://www.taotesting.com/user-guide/installation-and-upgrade/prerequisites/)
+- [Centos, Redhat and Fedora](https://www.taotesting.com/user-guide/installation-and-upgrade/centos-redhat-and-fedora/)
+- [MacOS Mojave](https://www.taotesting.com/user-guide/installation-and-upgrade/macos/)
+- [Ubuntu and Debian](https://www.taotesting.com/user-guide/installation-and-upgrade/ubuntu-and-debian/)
+- [Windows](https://www.taotesting.com/user-guide/installation-and-upgrade/windows/)
+- [Web Installer](https://www.taotesting.com/user-guide/installation-and-upgrade/web-installer/)
 
 ## Other TAO Resources
 
-- [Administrator Guide](https://adminguide.taotesting.com)
+- [Administrator Guide](https://www.taotesting.com/user-guide/managing-tao/introduction-to-managing-tao/)
 - [User Guide](https://userguide.taotesting.com)
 - [Technical Documentation](https://hub.taotesting.com)
 - [Forum](https://forum.taotesting.com)
@@ -36,8 +36,9 @@ Clone repository
 
     git clone https://github.com/oat-sa/package-tao.git
     
-Install via composer missing library and extensions
+Install via composer missing library and extensions. Composer version 2 doesn't work so you've to use version 1.
 
+    composer self-update --1
     composer install
     
 Add rw to www-data


### PR DESCRIPTION
Refers to tickets https://oat-sa.atlassian.net/browse/CGF-275 and completes tickets https://oat-sa.atlassian.net/servicedesk/customer/portal/29/UG-42 and https://oat-sa.atlassian.net/servicedesk/customer/portal/29/UG-43 on the online user guide itself.

Fixes 2 issues:
- Links to online instructions on how to install Tao Core are dead.
- `composer` version 2 (now the default) doesn't work with Tao's plugins made for `composer` version 1, until sprint 149. Added an instruction line on how to change `composer` version.

