### PR TITLE
fix upload-file-limit

### DIFF
--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -37,5 +37,10 @@ RUN { \
     echo 'opcache.load_comments=1'; \
 } >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
+RUN { \
+    echo 'upload_max_filesize=100M'; \
+    echo 'post_max_size=100M'; \
+} >> /usr/local/etc/php/conf.d/docker-php-core.ini
+
 RUN rm -rf /var/www/html \
     && chmod 0777 /tmp/


### PR DESCRIPTION
During debugging with client developer, who wanted to upload a big PCI file, I've realized the default file upload is set to 2 MB in the PHP config. I've updated it to 100 MB like it is set on the nginx level.

Test:
- Try to upload a file on PCI menu, that is bigger that 2 MB.